### PR TITLE
At the Request Snippet, the placeholder was Intent instead of Request

### DIFF
--- a/snippets/lambdaSDKPythonSnippet.json
+++ b/snippets/lambdaSDKPythonSnippet.json
@@ -33,7 +33,7 @@
     "exception_handler":{
         "prefix" : "askSDKPythonExceptionHandler",
         "body": [
-            "class AllExceptionHandler(AbstractRequestHandler):",
+            "class AllExceptionHandler(AbstractExceptionHandler):",
                 "\tdef can_handle(self, handler_input, exception):",
                 "\t\t# type: (HandlerInput) -> bool",
                 "\t\treturn True",

--- a/snippets/lambdaSDKPythonSnippet.json
+++ b/snippets/lambdaSDKPythonSnippet.json
@@ -2,7 +2,7 @@
     "request_handler" :{
         "prefix" : "askSDKPythonRequestHandler",
         "body": [
-            "class ${1:Intent}Handler(AbstractRequestHandler):",
+            "class ${1:Request}Handler(AbstractRequestHandler):",
                 "\tdef can_handle(self, handler_input):",
                 "\t\t# type: (HandlerInput) -> bool",
                 "\t\treturn is_request_type(\"${1}\")(handler_input)",


### PR DESCRIPTION
*Description of changes:*

- [X] At the Request Snippet the placeholder word was Intent instead of Request. Despite the plugin was using the right snippet the the placeholder was Intent.

- [X] Also changed the derived class name of the AllException snippet by AbstractExceptionHandler.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.